### PR TITLE
ci: workflow permissions — allow issues write at top-level

### DIFF
--- a/.github/workflows/copilot-regression-analysis.yml
+++ b/.github/workflows/copilot-regression-analysis.yml
@@ -1,5 +1,9 @@
 name: Copilot Regression Analysis
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   # Run on any push to any branch
   push: {}


### PR DESCRIPTION
Set top-level permissions so the workflow's GITHUB_TOKEN can post issue comments. This complements the job-level permissions and ensures runs use the intended permissions.